### PR TITLE
Changes git to https for submodule.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Vendor/KTCategories"]
 	path = Vendor/KTCategories
-	url = git@github.com:keighl/KTCategories.git
+	url = https://github.com:keighl/KTCategories.git


### PR DESCRIPTION
It's more preferred to use https instead of git for submodules with public repos to ease cloning without keys.
